### PR TITLE
Add optional inference params to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ pip install git+https://github.com/amazon-science/chronos-forecasting.git
 A minimal example showing how to perform inference using Chronos models:
 
 ```python
+# for plotting, run: pip install pandas matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -55,7 +56,14 @@ df = pd.read_csv("https://raw.githubusercontent.com/AileenNielsen/TimeSeriesAnal
 # or a left-padded 2D tensor with batch as the first dimension
 context = torch.tensor(df["#Passengers"])
 prediction_length = 12
-forecast = pipeline.predict(context, prediction_length)  # shape [num_series, num_samples, prediction_length]
+forecast = pipeline.predict(
+  context,
+  prediction_length,
+  num_samples=20,
+  temperature=1.0,
+  top_k=50,
+  top_p=1.0,
+) # forecast shape: [num_series, num_samples, prediction_length]
 
 # visualize the forecast
 forecast_index = range(len(df), len(df) + prediction_length)


### PR DESCRIPTION
*Description of changes:* This PR adds optional inference params such as `num_samples`, `top_k`, etc. to the example in the README for clarity. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
