### PR TITLE
Add pipeline.embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ To perform inference with Chronos models, install this package by running:
 pip install git+https://github.com/amazon-science/chronos-forecasting.git
 ```
 
-A minimal example showing how to perform inference using Chronos models:
+### Forecasting
+
+A minimal example showing how to perform forecasting using Chronos models:
 
 ```python
 # for plotting, run: pip install pandas matplotlib
@@ -77,6 +79,30 @@ plt.legend()
 plt.grid()
 plt.show()
 ```
+
+### Extracting Encoder Embeddings
+
+A minimal example showing how to extract encoder embeddings from Chronos models:
+
+```python
+import pandas as pd
+import torch
+from chronos import ChronosPipeline
+
+pipeline = ChronosPipeline.from_pretrained(
+  "amazon/chronos-t5-small",
+  device_map="cuda",
+  torch_dtype=torch.bfloat16,
+)
+
+df = pd.read_csv("https://raw.githubusercontent.com/AileenNielsen/TimeSeriesAnalysisWithPython/master/data/AirPassengers.csv")
+
+# context must be either a 1D tensor, a list of 1D tensors,
+# or a left-padded 2D tensor with batch as the first dimension
+context = torch.tensor(df["#Passengers"])
+embeddings, decoding_context = pipeline.embed(context)
+```
+
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ import torch
 from chronos import ChronosPipeline
 
 pipeline = ChronosPipeline.from_pretrained(
-  "amazon/chronos-t5-small",
-  device_map="cuda",
-  torch_dtype=torch.bfloat16,
+    "amazon/chronos-t5-small",
+    device_map="cuda",
+    torch_dtype=torch.bfloat16,
 )
 
 df = pd.read_csv("https://raw.githubusercontent.com/AileenNielsen/TimeSeriesAnalysisWithPython/master/data/AirPassengers.csv")
@@ -59,12 +59,12 @@ df = pd.read_csv("https://raw.githubusercontent.com/AileenNielsen/TimeSeriesAnal
 context = torch.tensor(df["#Passengers"])
 prediction_length = 12
 forecast = pipeline.predict(
-  context,
-  prediction_length,
-  num_samples=20,
-  temperature=1.0,
-  top_k=50,
-  top_p=1.0,
+    context,
+    prediction_length,
+    num_samples=20,
+    temperature=1.0,
+    top_k=50,
+    top_p=1.0,
 ) # forecast shape: [num_series, num_samples, prediction_length]
 
 # visualize the forecast
@@ -90,9 +90,9 @@ import torch
 from chronos import ChronosPipeline
 
 pipeline = ChronosPipeline.from_pretrained(
-  "amazon/chronos-t5-small",
-  device_map="cuda",
-  torch_dtype=torch.bfloat16,
+    "amazon/chronos-t5-small",
+    device_map="cuda",
+    torch_dtype=torch.bfloat16,
 )
 
 df = pd.read_csv("https://raw.githubusercontent.com/AileenNielsen/TimeSeriesAnalysisWithPython/master/data/AirPassengers.csv")
@@ -100,7 +100,7 @@ df = pd.read_csv("https://raw.githubusercontent.com/AileenNielsen/TimeSeriesAnal
 # context must be either a 1D tensor, a list of 1D tensors,
 # or a left-padded 2D tensor with batch as the first dimension
 context = torch.tensor(df["#Passengers"])
-embeddings, decoding_context = pipeline.embed(context)
+embeddings, tokenizer_state = pipeline.embed(context)
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chronos"
-version = "1.1.0"
+version = "1.0.0"
 requires-python = ">=3.8"
 license = {file = "LICENSE"}
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chronos"
-version = "1.0.0"
+version = "1.1.0"
 requires-python = ">=3.8"
 license = {file = "LICENSE"}
 dependencies = [

--- a/src/chronos/chronos.py
+++ b/src/chronos/chronos.py
@@ -202,7 +202,6 @@ class ChronosModel(nn.Module):
     def device(self):
         return self.model.device
 
-    @torch.no_grad()
     def encode(
         self,
         input_ids: torch.Tensor,
@@ -342,10 +341,12 @@ class ChronosPipeline:
 
         return context
 
+    @torch.no_grad()
     def embed(
         self, context: Union[torch.Tensor, List[torch.Tensor]]
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Get encoder embeddings for the given time series.
+        """
+        Get encoder embeddings for the given time series.
 
         Parameters
         ----------

--- a/src/chronos/chronos.py
+++ b/src/chronos/chronos.py
@@ -362,9 +362,10 @@ class ChronosPipeline:
             A tuple of two tensors: the encoder embeddings and the decoding_context,
             e.g., the scale of the time series in the case of mean scaling.
             The encoder embeddings are shaped (batch_size, context_length, d_model)
-            or (batch_size, context_length + 1, d_model), where the extra 1 is for EOS.
-            If your original time series were shorter than the model's context_length,
-            please slice the returned embeddings along the time axis accordingly.
+            or (batch_size, context_length + 1, d_model), where context_length
+            is the size of the context along the time axis if a 2D tensor was provided
+            or the length of the longest time series, if a list of 1D tensors was
+            provided, and the extra 1 is for EOS.
         """
         context = self._prepare_and_validate_context(context=context)
         token_ids, attention_mask, decoding_context = self.tokenizer.input_transform(

--- a/test/test_chronos.py
+++ b/test/test_chronos.py
@@ -186,12 +186,9 @@ def test_pipeline_embed(torch_dtype: str):
         device_map="cpu",
         torch_dtype=torch_dtype,
     )
-    model_context_length = pipeline.model.config.context_length
-    expected_embed_length = model_context_length + (
-        1 if pipeline.model.config.use_eos_token else 0
-    )
     d_model = pipeline.model.model.config.d_model
     context = 10 * torch.rand(size=(4, 16)) + 10
+    expected_embed_length = 16 + (1 if pipeline.model.config.use_eos_token else 0)
 
     # input: tensor of shape (batch_size, context_length)
 


### PR DESCRIPTION
*Description of changes:* This PR adds `pipeline.embed` which extracts encoder embeddings from the model. These embeddings may be useful for some downstream tasks such as classification, so this is useful to have. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
