### PR TITLE
Remove Unnecessary F-strings

### DIFF
--- a/src/chronos/chronos.py
+++ b/src/chronos/chronos.py
@@ -432,7 +432,7 @@ class ChronosPipeline:
         if prediction_length > self.model.config.prediction_length:
             msg = (
                 f"We recommend keeping prediction length <= {self.model.config.prediction_length}. "
-                f"The quality of longer predictions may degrade since the model is not optimized for it. "
+                "The quality of longer predictions may degrade since the model is not optimized for it. "
             )
             if limit_prediction_length:
                 msg += "You can turn off this check by setting `limit_prediction_length=False`."


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
This codemod converts any f-strings without interpolated variables into regular strings.
In these cases the use of f-string is not necessary; a simple string literal is sufficient. 

While in some (extreme) cases we might expect a very modest performance
improvement, in general this is a fix that improves the overall cleanliness and
quality of your code.

```diff
- var = f"hello"
+ var = "hello"
  ...
```

<details>
  <summary>More reading</summary>

  * [https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/f-string-without-interpolation.html](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/f-string-without-interpolation.html)
  * [https://github.com/Instagram/LibCST/blob/main/libcst/codemod/commands/unnecessary_format_string.py](https://github.com/Instagram/LibCST/blob/main/libcst/codemod/commands/unnecessary_format_string.py)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/remove-unnecessary-f-str](https://docs.pixee.ai/codemods/python/pixee_python_remove-unnecessary-f-str)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Fchronos-forecasting%7C0822cf23d3ea7d0de7d1b3685ba6e93f9e17ca0d)

<!--{"type":"DRIP","codemod":"pixee:python/remove-unnecessary-f-str"}-->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
