### PR TITLE
Remove float32 casting for cumsum

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "torch~=2.1",         # package was tested on 2.2
     "transformers~=4.31",
     "accelerate",
-    "mlx~=0.9.0"
+    "mlx~=0.10.0"
 ]
 
 [project.optional-dependencies]

--- a/test/test_chronos_mlx.py
+++ b/test/test_chronos_mlx.py
@@ -70,6 +70,17 @@ def test_pipeline_predict(dtype: str):
     )
     validate_array(samples, (1, 7, 65))
 
+    # test non-default inference params
+    samples = pipeline.predict(
+        context,
+        num_samples=12,
+        prediction_length=3,
+        top_p=0.7,
+        top_k=32,
+        temperature=0.9,
+    )
+    validate_array(samples, (4, 12, 3))
+
 
 @pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
 def test_pipeline_embed(dtype: str):


### PR DESCRIPTION
*Description of changes:* This PR removes casting to `fp32` for the `cumsum` operation and upgrades `mlx` to `~=0.10.0` which adds `bf16` support for `cumsum`. 

Related: https://github.com/ml-explore/mlx/issues/959

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
