### PR TITLE
Add one space after --config in training readme

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -74,7 +74,7 @@
 - Start the training (or fine-tuning) job:
     ```sh
     # On single GPU
-    CUDA_VISIBLE_DEVICES=0 python training/train.py --config/path/to/modified/config.yaml
+    CUDA_VISIBLE_DEVICES=0 python training/train.py --config /path/to/modified/config.yaml
 
     # On multiple GPUs (example with 8 GPUs)
     torchrun --nproc-per-node=8 training/train.py --config /path/to/modified/config.yaml


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There is one space missing in the example training command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
