### PR TITLE
Relax torch and transformers versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ version = "1.2.0"
 requires-python = ">=3.8"
 license = { file = "LICENSE" }
 dependencies = [
-    "torch~=2.1",         # package was tested on 2.2
-    "transformers~=4.31,<4.41",
+    "torch~=2.0",         # package was tested on 2.2
+    "transformers~=4.30,<4.41",
     "accelerate",
 ]
 


### PR DESCRIPTION
*Description of changes:* This PR relaxes `torch` and `transformers` versions to allow for older versions that were used during original training. This is needed in light of recent `torch`/`transformers` versions being slower with DDP.

Relevant issues (but the problem may be deeper than these):

- https://github.com/huggingface/transformers/issues/30840
- https://github.com/pytorch/pytorch/issues/127077
- https://github.com/NVIDIA/nccl/issues/1298


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
