### PR TITLE
Split `input_transform` into `context_input_transform` and `label_input_transform`

### DIFF
--- a/scripts/training/train.py
+++ b/scripts/training/train.py
@@ -387,9 +387,11 @@ class ChronosDataset(IterableDataset, ShuffleMixin):
 
     def to_hf_format(self, entry: dict) -> dict:
         past_target = torch.tensor(entry["past_target"]).unsqueeze(0)
-        input_ids, attention_mask, scale = self.tokenizer.input_transform(past_target)
+        input_ids, attention_mask, scale = self.tokenizer.context_input_transform(
+            past_target
+        )
         future_target = torch.tensor(entry["future_target"]).unsqueeze(0)
-        labels, labels_mask, _ = self.tokenizer.input_transform(future_target, scale)
+        labels, labels_mask = self.tokenizer.label_input_transform(future_target, scale)
         labels[labels_mask == 0] = -100
         return {
             "input_ids": input_ids.squeeze(0),

--- a/scripts/training/train.py
+++ b/scripts/training/train.py
@@ -41,7 +41,7 @@ from gluonts.transform import (
     ExpectedNumInstanceSampler,
 )
 
-from chronos import ChronosConfig, Tokenizer
+from chronos import ChronosConfig, ChronosTokenizer
 
 
 app = typer.Typer(pretty_exceptions_enable=False)
@@ -303,7 +303,7 @@ class ChronosDataset(IterableDataset, ShuffleMixin):
         self,
         datasets: list,
         probabilities: List[float],
-        tokenizer: Tokenizer,
+        tokenizer: ChronosTokenizer,
         context_length: int = 512,
         prediction_length: int = 64,
         drop_prob: float = 0.2,

--- a/scripts/training/train.py
+++ b/scripts/training/train.py
@@ -41,7 +41,7 @@ from gluonts.transform import (
     ExpectedNumInstanceSampler,
 )
 
-from chronos import ChronosConfig, ChronosTokenizer
+from chronos import ChronosConfig, Tokenizer
 
 
 app = typer.Typer(pretty_exceptions_enable=False)
@@ -303,7 +303,7 @@ class ChronosDataset(IterableDataset, ShuffleMixin):
         self,
         datasets: list,
         probabilities: List[float],
-        tokenizer: ChronosTokenizer,
+        tokenizer: Tokenizer,
         context_length: int = 512,
         prediction_length: int = 64,
         drop_prob: float = 0.2,

--- a/src/chronos/__init__.py
+++ b/src/chronos/__init__.py
@@ -5,7 +5,7 @@ from .chronos import (
     ChronosConfig,
     ChronosModel,
     ChronosPipeline,
-    ChronosTokenizer,
+    Tokenizer,
     MeanScaleUniformBins,
 )
 
@@ -13,6 +13,6 @@ __all__ = [
     "ChronosConfig",
     "ChronosModel",
     "ChronosPipeline",
-    "ChronosTokenizer",
+    "Tokenizer",
     "MeanScaleUniformBins",
 ]

--- a/src/chronos/__init__.py
+++ b/src/chronos/__init__.py
@@ -5,7 +5,7 @@ from .chronos import (
     ChronosConfig,
     ChronosModel,
     ChronosPipeline,
-    Tokenizer,
+    ChronosTokenizer,
     MeanScaleUniformBins,
 )
 
@@ -13,6 +13,6 @@ __all__ = [
     "ChronosConfig",
     "ChronosModel",
     "ChronosPipeline",
-    "Tokenizer",
+    "ChronosTokenizer",
     "MeanScaleUniformBins",
 ]

--- a/src/chronos/chronos.py
+++ b/src/chronos/chronos.py
@@ -368,7 +368,7 @@ class ChronosPipeline:
     """
 
     tokenizer: ChronosTokenizer
-    model: nn.Module
+    model: ChronosModel
     forecast_type: Literal["samples", "quantiles"] = "samples"
 
     def _prepare_and_validate_context(

--- a/src/chronos/chronos.py
+++ b/src/chronos/chronos.py
@@ -84,9 +84,10 @@ class ChronosTokenizer:
             which input observations are not ``torch.nan`` (i.e. not
             missing nor padding).
         tokenizer_state
-            An object that will be passed to ``output_transform``.
-            Contains the relevant information to decode output samples into
-            real values, such as location and scale parameters.
+            An object that can be passed to ``label_input_transform``
+            and ``output_transform``. Contains the relevant information
+            to decode output samples into real values,
+            such as location and scale parameters.
         """
         raise NotImplementedError()
 

--- a/src/chronos/chronos.py
+++ b/src/chronos/chronos.py
@@ -64,7 +64,7 @@ class ChronosTokenizer:
         context: torch.Tensor,
     ) -> Tuple:
         """
-        Turn a batch of time series into token IDs, attention map, and scale.
+        Turn a batch of time series into token IDs, attention map, and tokenizer_state.
 
         Parameters
         ----------
@@ -92,7 +92,7 @@ class ChronosTokenizer:
 
     def label_input_transform(self, label: torch.Tensor, tokenizer_state: Any) -> Tuple:
         """
-        Turn a batch of label slices of time series into token IDs, attention map
+        Turn a batch of label slices of time series into token IDs and attention map
         using the ``tokenizer_state`` provided by ``context_input_transform``.
 
         Parameters

--- a/src/chronos/chronos.py
+++ b/src/chronos/chronos.py
@@ -72,13 +72,6 @@ class ChronosTokenizer:
             A tensor shaped (batch_size, time_length), containing the
             timeseries to forecast. Use left-padding with ``torch.nan``
             to align time series of different lengths.
-        tokenizer_state
-            An object returned by ``input_transform`` containing
-            relevant information to preprocess data, such as location and
-            scale. The nature of this depends on the specific tokenizer.
-            This is useful when tokenizing the label (for training), in
-            order to use the same scaling used to tokenize the context;
-            when tokenizing the context, this argument should be ignored.
 
         Returns
         -------
@@ -98,6 +91,34 @@ class ChronosTokenizer:
         raise NotImplementedError()
 
     def label_input_transform(self, label: torch.Tensor, tokenizer_state: Any) -> Tuple:
+        """
+        Turn a batch of label slices of time series into token IDs, attention map
+        using the ``tokenizer_state`` provided by ``context_input_transform``.
+
+        Parameters
+        ----------
+        context
+            A tensor shaped (batch_size, time_length), containing the
+            timeseries to forecast. Use left-padding with ``torch.nan``
+            to align time series of different lengths.
+        tokenizer_state
+            An object returned by ``context_input_transform`` containing
+            relevant information to preprocess data, such as location and
+            scale. The nature of this depends on the specific tokenizer.
+            This is used for tokenizing the label, in order to use the same
+            scaling used to tokenize the context.
+
+        Returns
+        -------
+        token_ids
+            A tensor of integers, shaped (batch_size, time_length + 1)
+            if ``config.use_eos_token`` and (batch_size, time_length)
+            otherwise, containing token IDs for the input series.
+        attention_mask
+            A boolean tensor, same shape as ``token_ids``, indicating
+            which input observations are not ``torch.nan`` (i.e. not
+            missing nor padding).
+        """
         raise NotImplementedError()
 
     def output_transform(

--- a/src/chronos/chronos.py
+++ b/src/chronos/chronos.py
@@ -101,11 +101,7 @@ class Tokenizer:
         """
         raise NotImplementedError()
 
-    def label_input_transform(
-        self,
-        context: torch.Tensor,
-        tokenizer_state: Any = None,
-    ) -> Tuple:
+    def label_input_transform(self, label: torch.Tensor, tokenizer_state: Any) -> Tuple:
         raise NotImplementedError()
 
     def output_transform(
@@ -191,7 +187,7 @@ class MeanScaleUniformBins(Tokenizer):
     def context_input_transform(
         self, context: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        batch_size, length = context.shape
+        length = context.shape[-1]
 
         if length > self.config.context_length:
             context = context[..., -self.config.context_length :]
@@ -206,14 +202,12 @@ class MeanScaleUniformBins(Tokenizer):
         return token_ids, attention_mask, scale
 
     def label_input_transform(
-        self, context: torch.Tensor, scale: torch.Tensor
+        self, label: torch.Tensor, scale: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        batch_size, length = context.shape
+        length = label.shape[-1]
 
         assert length == self.config.prediction_length
-        token_ids, attention_mask, _ = self._input_transform(
-            context=context, scale=scale
-        )
+        token_ids, attention_mask, _ = self._input_transform(context=label, scale=scale)
 
         if self.config.use_eos_token:
             token_ids, attention_mask = self._append_eos_token(

--- a/src/chronos/chronos.py
+++ b/src/chronos/chronos.py
@@ -390,7 +390,6 @@ class ChronosPipeline:
 
     tokenizer: ChronosTokenizer
     model: ChronosModel
-    forecast_type: Literal["samples", "quantiles"] = "samples"
 
     def _prepare_and_validate_context(
         self, context: Union[torch.Tensor, List[torch.Tensor]]

--- a/src/chronos/chronos.py
+++ b/src/chronos/chronos.py
@@ -177,6 +177,17 @@ class MeanScaleUniformBins(Tokenizer):
 
         return token_ids, attention_mask, scale
 
+    def _append_eos_token(
+        self, token_ids: torch.Tensor, attention_mask: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        batch_size = token_ids.shape[0]
+        eos_tokens = torch.full((batch_size, 1), fill_value=self.config.eos_token_id)
+        token_ids = torch.concat((token_ids, eos_tokens), dim=1)
+        eos_mask = torch.full((batch_size, 1), fill_value=True)
+        attention_mask = torch.concat((attention_mask, eos_mask), dim=1)
+
+        return token_ids, attention_mask
+
     def context_input_transform(
         self, context: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -188,12 +199,9 @@ class MeanScaleUniformBins(Tokenizer):
         token_ids, attention_mask, scale = self._input_transform(context=context)
 
         if self.config.use_eos_token and self.config.model_type == "seq2seq":
-            eos_tokens = torch.full(
-                (batch_size, 1), fill_value=self.config.eos_token_id
+            token_ids, attention_mask = self._append_eos_token(
+                token_ids=token_ids, attention_mask=attention_mask
             )
-            token_ids = torch.concat((token_ids, eos_tokens), dim=1)
-            eos_mask = torch.full((batch_size, 1), fill_value=True)
-            attention_mask = torch.concat((attention_mask, eos_mask), dim=1)
 
         return token_ids, attention_mask, scale
 
@@ -208,12 +216,9 @@ class MeanScaleUniformBins(Tokenizer):
         )
 
         if self.config.use_eos_token:
-            eos_tokens = torch.full(
-                (batch_size, 1), fill_value=self.config.eos_token_id
+            token_ids, attention_mask = self._append_eos_token(
+                token_ids=token_ids, attention_mask=attention_mask
             )
-            token_ids = torch.concat((token_ids, eos_tokens), dim=1)
-            eos_mask = torch.full((batch_size, 1), fill_value=True)
-            attention_mask = torch.concat((attention_mask, eos_mask), dim=1)
 
         return token_ids, attention_mask
 

--- a/test/test_chronos.py
+++ b/test/test_chronos.py
@@ -41,7 +41,7 @@ def test_tokenizer_consistency(n_numerical_tokens: int, n_special_tokens: int):
     token_ids, _, _ = tokenizer._input_transform(context, scale=scale)
 
     samples = tokenizer.output_transform(
-        token_ids.unsqueeze(1),  # remove final EOS, add sample dimension
+        token_ids.unsqueeze(1),  # add sample dimension
         scale=scale,
     )
 

--- a/test/test_chronos.py
+++ b/test/test_chronos.py
@@ -38,10 +38,10 @@ def test_tokenizer_consistency(n_numerical_tokens: int, n_special_tokens: int):
     context = tokenizer.centers.unsqueeze(0)  # add batch dimension
     scale = torch.ones((1,))  # fix the scale to one to turn off scaling
 
-    token_ids, _, _ = tokenizer.input_transform(context, scale=scale)
+    token_ids, _, _ = tokenizer._input_transform(context, scale=scale)
 
     samples = tokenizer.output_transform(
-        token_ids[:, :-1].unsqueeze(1),  # remove final EOS, add sample dimension
+        token_ids.unsqueeze(1),  # remove final EOS, add sample dimension
         scale=scale,
     )
 
@@ -85,7 +85,7 @@ def test_tokenizer_fixed_data(
     )
     batch_size, _ = context.shape
 
-    token_ids, attention_mask, scale = tokenizer.input_transform(context)
+    token_ids, attention_mask, scale = tokenizer.context_input_transform(context)
 
     assert token_ids.shape == (batch_size, context_length + 1 * use_eos_token)
     assert all(token_ids[:, 0] == torch.tensor([0]).repeat(batch_size))
@@ -136,7 +136,7 @@ def test_tokenizer_random_data(use_eos_token: bool):
         ]
     )
 
-    token_ids, attention_mask, scale = tokenizer.input_transform(context)
+    token_ids, attention_mask, scale = tokenizer.context_input_transform(context)
 
     assert token_ids.shape == (
         *context.shape[:-1],


### PR DESCRIPTION
*Description of changes:* This splits `input_transform` into `context_input_transform` and `label_input_transform`. Previously, `input_transform` was being used for both context and label during training which would lead to incorrect results where `prediction_length` > `context_length`.

TODO:

- [x] Update docstrings
- [x] Test the training script

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
