### PR TITLE
Enhance training script: auto tf32 detection and reorder default seed setting

### DIFF
--- a/scripts/training/train.py
+++ b/scripts/training/train.py
@@ -496,7 +496,7 @@ def main(
     ):
         log_on_main(
             "TF32 format is only available on devices with compute capability >= 8. "
-            "Setting tf32 to false.",
+            "Setting tf32 to False.",
             logger,
         )
         tf32 = False


### PR DESCRIPTION
*Description of changes:* Automatically set `tf32` to `False` if used on an older NVIDIA GPU. Reorder seed so that the seed is saved as part of the training config. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
