### PR TITLE
Uncap transformers dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.8"
 license = { file = "LICENSE" }
 dependencies = [
     "torch~=2.0",         # package was tested on 2.2
-    "transformers~=4.30,<4.41",
+    "transformers~=4.30",
     "accelerate",
 ]
 


### PR DESCRIPTION
*Issue #, if available:* We had to cap transformers in #77 due to https://github.com/huggingface/transformers/issues/30892. The issue was solved and released in [transformers 4.41.1](https://github.com/huggingface/transformers/releases/tag/v4.41.1).

*Description of changes:* Remove previous version cap introduced in #77.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
