### PR TITLE
Ensure model parameters are contiguous to allow saving model weights

### DIFF
--- a/scripts/training/train.py
+++ b/scripts/training/train.py
@@ -678,6 +678,14 @@ def main(
         remove_unused_columns=False,
     )
 
+    # make sure all model parameters are contiguous on memory. This is necessary to save model state dict as safetensor
+    for name, param in model.named_parameters():
+        if not param.is_contiguous():
+            print(f"Parameter {name} is not contiguous. Making it contiguous.")
+            param.data = param.data.contiguous()
+        else:
+            print(f"Parameter {name} is already contiguous.")
+
     # Create Trainer instance
     trainer = Trainer(
         model=model,


### PR DESCRIPTION
Issue: with the current training script, saving the model weights (in the huggingface safetensor format) throws an error because the model parameters are not necessarily contiguous in memory (operations like permuting or transposing can cause this). I have therefore added a small block of code to ensure the model parameters are contiguous before training with the transformers trainer. 

With this change, there is no longer an error when saving a model checkpoint. In addition, I notice a 2x training speed boost on my GPU server.

I wasn't sure how y'all want to structure/organize the codebase, but I mainly wanted to point out this issue and an easy fix. I hope this helps!