### PR TITLE
Fix number of quantisation buckets

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: 1.2.0
+cff-version: 1.2.1
 title: "Chronos: Learning the Language of Time Series"
 message: "If you find Chronos models useful for your research, please consider citing the associated paper."
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: 1.2.1
+cff-version: 1.2.0
 title: "Chronos: Learning the Language of Time Series"
 message: "If you find Chronos models useful for your research, please consider citing the associated paper."
 authors:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chronos"
-version = "1.2.0"
+version = "1.2.1"
 requires-python = ">=3.8"
 license = { file = "LICENSE" }
 dependencies = [

--- a/src/chronos/chronos.py
+++ b/src/chronos/chronos.py
@@ -5,7 +5,6 @@ import warnings
 from dataclasses import dataclass
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
-import chronos
 import torch
 import torch.nn as nn
 from transformers import (
@@ -15,6 +14,8 @@ from transformers import (
     GenerationConfig,
     PreTrainedModel,
 )
+
+import chronos
 
 
 @dataclass
@@ -155,7 +156,11 @@ class MeanScaleUniformBins(ChronosTokenizer):
         self.centers = torch.linspace(
             low_limit,
             high_limit,
-            config.n_tokens - config.n_special_tokens - 1,
+            config.n_tokens
+            - config.n_special_tokens
+            - 2,  # `n` centers result in `n+2` buckets, so we want to leave out the
+            # number of special tokens and subtract 2. This way, the total number of
+            # buckets coincides with `n_tokens`, as required.
         )
         self.boundaries = torch.concat(
             (

--- a/src/chronos/chronos.py
+++ b/src/chronos/chronos.py
@@ -191,8 +191,7 @@ class MeanScaleUniformBins(ChronosTokenizer):
             + self.config.n_special_tokens
         )
 
-        token_ids.clamp_(0, self.config.n_tokens - 1)  # clip the largest token to avoid
-        # out of bounds tokens (must be 0<=token_id<n_tokens). See comment in __init__().
+        token_ids.clamp_(0, self.config.n_tokens - 1)
 
         token_ids[~attention_mask] = self.config.pad_token_id
 

--- a/src/chronos/chronos.py
+++ b/src/chronos/chronos.py
@@ -160,7 +160,7 @@ class MeanScaleUniformBins(ChronosTokenizer):
             - config.n_special_tokens
             - 2,  # `n` centers result in `n+2` buckets, so we want to leave out the
             # number of special tokens and subtract 2. This way, the total number of
-            # buckets coincides with `n_tokens`, as required.
+            # tokens coincides with `n_tokens`, as required.
         )
         self.boundaries = torch.concat(
             (

--- a/src/chronos/chronos.py
+++ b/src/chronos/chronos.py
@@ -156,9 +156,7 @@ class MeanScaleUniformBins(ChronosTokenizer):
         self.centers = torch.linspace(
             low_limit,
             high_limit,
-            config.n_tokens
-            - config.n_special_tokens
-            - 1,
+            config.n_tokens - config.n_special_tokens - 1,
         )
         self.boundaries = torch.concat(
             (

--- a/src/chronos/chronos.py
+++ b/src/chronos/chronos.py
@@ -158,10 +158,7 @@ class MeanScaleUniformBins(ChronosTokenizer):
             high_limit,
             config.n_tokens
             - config.n_special_tokens
-            - 1,  # this results in one bucket too many, so the total number of tokens is
-            # `n_tokens + 1` (including the special tokens). This is addressed below by
-            # clipping, and was kept this way to avoid divergence with the original
-            # trained models.
+            - 1,
         )
         self.boundaries = torch.concat(
             (

--- a/test/test_chronos.py
+++ b/test/test_chronos.py
@@ -268,9 +268,35 @@ def test_tokenizer_number_of_buckets(n_tokens):
 
     n_numerical_tokens = config.n_tokens - config.n_special_tokens
 
-    # We want a total of `n_numerical_tokens` numerical tokens, that is,
-    # `n_numerical_tokens` buckets for the values of the time series.
-    # This means that we need `n_numerical_tokens - 1` boundaries, and
-    # `n_numerical_tokens - 2` centers.
-    assert len(tokenizer.centers) == (n_numerical_tokens - 2)
-    assert len(tokenizer.boundaries) == (n_numerical_tokens - 1)
+    # The tokenizer has one bucket too many as a result of an early bug. In order to
+    # keep consistent with the original trained models, this is kept as it is. However,
+    # token ids are clipped to a maximum of `n_tokens - 1` to avoid out-of-bounds errors.
+    assert len(tokenizer.centers) == (n_numerical_tokens - 1)
+    assert len(tokenizer.boundaries) == n_numerical_tokens
+
+
+@pytest.mark.parametrize("n_tokens", [10, 1000, 10000])
+def test_token_clipping(n_tokens):
+    config = ChronosConfig(
+        tokenizer_class="MeanScaleUniformBins",
+        tokenizer_kwargs={"low_limit": -15, "high_limit": 15},
+        n_tokens=n_tokens,
+        n_special_tokens=2,
+        pad_token_id=0,
+        eos_token_id=1,
+        use_eos_token=True,
+        model_type="seq2seq",
+        context_length=512,
+        prediction_length=64,
+        num_samples=20,
+        temperature=1.0,
+        top_k=50,
+        top_p=1.0,
+    )
+    tokenizer = config.create_tokenizer()
+
+    huge_value = 1e22  # this large value is assigned to the largest bucket
+    token_ids, _, _ = tokenizer._input_transform(
+        context=torch.tensor([[huge_value]]), scale=torch.tensor(([1]))
+    )
+    assert token_ids[0, 0] == config.n_tokens - 1  # and it's clipped to n_tokens - 1


### PR DESCRIPTION
Fixes https://github.com/amazon-science/chronos-forecasting/issues/181.

Chronos' tokenizer has a vocabulary size of `n_tokens`. Among these, there are `n_special_tokens` reserved for EOS, PAD, etc. and `n_tokens - n_special_tokens` allocated to numerical values. However, the provided `MeanScaleUniformBins` tokenizer creates` n_tokens - n_special_tokens + 1` different buckets, resulting in a total of `n_tokens + 1` possible tokens. This causes training and inference errors when one of the data points gets allocated to the largest bucket, as the model requires 0 <= token_id < n_tokens.

This PR modifies the `MeanScaleUniformBins` tokenizer, so that it creates one less bucket for numerical values.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
