### PR TITLE
Fix scaling that affects constant series

### DIFF
--- a/src/chronos/chronos_bolt.py
+++ b/src/chronos/chronos_bolt.py
@@ -88,7 +88,7 @@ class InstanceNorm(nn.Module):
             scale = torch.nan_to_num(
                 torch.nanmean((x - loc).square(), dim=-1, keepdim=True).sqrt(), nan=1.0
             )
-            scale = torch.where(scale == 0, torch.abs(loc) + self.eps, scale)
+            scale = torch.where(scale == 0, self.eps, scale)
         else:
             loc, scale = loc_scale
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* This is embarrassing. This PR fixes a scaling issue that affected constant time series where scale is assigned to be `abs(loc) + eps` instead of just `eps` in case of constant series. Fortunately, this seems to only affect inference because the `loc` and `scale` are not actually used in the model. I am not sure what I was thinking when I wrote this function. 

Here are results for a batch of random constant time series with random lengths. We see the the forecast is much better after the fix. 

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/4f8a88e0-5e46-42fb-ad7e-0ac667254135) | ![image](https://github.com/user-attachments/assets/a1bfb2a5-f9fc-4198-a3dd-9c627e2638c9) |


### Repro

```py
import torch
from chronos import ChronosBoltPipeline

torch.manual_seed(0)

pipeline = ChronosBoltPipeline.from_pretrained("amazon/chronos-bolt-small")
num_series = 10
lengths = torch.randint(16, 2048, (num_series,)).tolist()
context = [torch.full((lengths[i],), fill_value=i) for i in range(num_series)]
predictions, _ = pipeline.predict_quantiles(context, quantile_levels=[0.1, 0.5, 0.9])

import matplotlib.pyplot as plt

fig, axn = plt.subplots(nrows=num_series, figsize=(5, num_series * 1.2))

for idx, (ctx, pred) in enumerate(zip(context, predictions)):
    forecast_index = range(len(ctx), len(ctx) + 64)
    low, median, high = pred[:, 0], pred[:, 1], pred[:, 2]

    axn[idx].plot(ctx, color="royalblue", label="historical data")
    axn[idx].plot(forecast_index, median, color="tomato", label="median forecast")
    axn[idx].fill_between(forecast_index, low, high, color="tomato", alpha=0.3, label="80% prediction interval")
    axn[idx].set_ylim(ctx[0] - 0.5, ctx[0] + 0.5)

fig.tight_layout()
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
