### PR TITLE
nit: fix axis in quantile loss computation

### DIFF
--- a/src/chronos/chronos_bolt.py
+++ b/src/chronos/chronos_bolt.py
@@ -363,7 +363,7 @@ class ChronosBoltModelForForecasting(T5PreTrainedModel):
                 )
                 * target_mask.float()
             )
-            loss = loss.mean(dim=-2)  # Mean over prediction horizon
+            loss = loss.mean(dim=-1)  # Mean over prediction horizon
             loss = loss.sum(dim=-1)  # Sum over quantile levels
             loss = loss.mean()  # Mean over batch
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Nit change of the shape in the quantile loss computation. The variable `loss` ([here](https://github.com/jbial/chronos-forecasting/blob/6a9c8dadac04eb85befc935043e3e2cce914267f/src/chronos/chronos_bolt.py#L355C13-L368C50)) has shape (B, num quantiles, T), so to mean over the prediction horizon (match the comment on line 366), the dim should be -1 instead of -2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
