### PR TITLE
Treat notebooks as documentation in linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.ipynb linguist-documentation


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This PR updates `.gitattributes` to treat notebooks as documentation rather than code when computing language statistics. See: https://github.com/github-linguist/linguist/issues/3282


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
