### PR TITLE
fix validate_and_prepare_single_dict_task by separating "past only" and "future known" cov keys

### DIFF
--- a/src/chronos/chronos2/dataset.py
+++ b/src/chronos/chronos2/dataset.py
@@ -123,7 +123,7 @@ def validate_and_prepare_single_dict_task(
         )
 
     # create ordered keys: past-only first, then known-future (so known-future are the last rows)
-    task_past_only_keys = [k for k in task_covariates_keys if k not in task_future_covariates_keys] # past_only_keys
+    task_past_only_keys = [k for k in task_covariates_keys if k not in task_future_covariates_keys]  # past_only_keys
     task_ordered_covariate_keys = task_past_only_keys + task_future_covariates_keys
 
     task_past_covariates_list: list[torch.Tensor] = []


### PR DESCRIPTION
Closes #345 

Hi @abdulfatir 
Here is the bugfix about the function "validate_and_prepare_single_dict_task", which had 2 issue points:

1. Originally, one of this func return, the "task_n_future_covariates", will return the ["past only" + "future known"]covariates number, by `task_n_future_covariates = len(task_future_covariates_list)` as `task_future_covariates_list ` is filled by for` key in task_covariates_keys`
2. The code seems not to guarantee the last "future known" rows are atcually what we expected, even there is a sorted option.

So, this PR fixed them by separating "past only" and "future known" covs from the "past_covariates" input, and explicitly put the "past only" covs rows above "future known" cov rows, supported by a temp list "ordered_covariate_keys".