### PR TITLE
Count notebooks as python in language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-.ipynb linguist-documentation
+*.ipynb linguist-language=Python


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The repo is classified as a Jupyter Notebook repo. This PR attempts to fix this by counting notebooks as python files instead of a separate thing. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
