### PR TITLE
Set `num_workers=0` in Chronos-2 test data loader

### DIFF
--- a/src/chronos/chronos2/pipeline.py
+++ b/src/chronos/chronos2/pipeline.py
@@ -542,7 +542,7 @@ class Chronos2Pipeline(BaseChronosPipeline):
             mode=DatasetMode.TEST,
         )
         test_loader = DataLoader(
-            test_dataset, batch_size=None, num_workers=0, pin_memory=True, shuffle=False, drop_last=False
+            test_dataset, batch_size=None, pin_memory=True, shuffle=False, drop_last=False
         )
 
         all_predictions: list[torch.Tensor] = []


### PR DESCRIPTION
By default, the `transformers` library sets the `num_workers` argument of the PyTorch DataLoader to `0`, ensuring out-of-the-box compatibility across different platforms.

*Issue #, if available:*

*Description of changes:*

Set the DataLoader `num_workers` argument to `0` to improve cross-platform compatibility, particularly on Windows systems where multiprocessing requires guarded execution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
