### PR TITLE
Mask past-only covariates during loss computation

### DIFF
--- a/src/chronos/chronos2/dataset.py
+++ b/src/chronos/chronos2/dataset.py
@@ -477,6 +477,7 @@ class Chronos2Dataset(IterableDataset):
             task_n_covariates,
             task_n_future_covariates,
         ) = self.tasks[task_idx]
+        task_past_tensor, task_future_tensor = task_past_tensor.clone(), task_future_tensor.clone()
         task_n_past_only_covariates = task_n_covariates - task_n_future_covariates
 
         full_length = task_past_tensor.shape[-1]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This PR masks rows corresponding to all covariates in the future target. Specifically, this is to avoid the contribution of past-only covariates in loss computation. The previous setup was correct from the perspective of pretraining but I think this makes more sense for fine-tuning. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
