### PR TITLE
Remove `fev` from extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ path = "src/chronos/__about__.py"
 extras = [
   "boto3>=1.10,<2",
   "peft>=0.13.0,<0.18",
-  "fev>=0.6.1",
   "pandas[pyarrow]>=2.0,<2.4",
 ]
 test = [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* `fev` introduces some dependencies which causes issues with `autogluon` installation. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
