### PR TITLE
Chronos-2: set default dataloader_num_workers=0 in Trainer

### DIFF
--- a/src/chronos/chronos2/pipeline.py
+++ b/src/chronos/chronos2/pipeline.py
@@ -265,7 +265,7 @@ class Chronos2Pipeline(BaseChronosPipeline):
             report_to="none",
             max_steps=num_steps,
             gradient_accumulation_steps=1,
-            dataloader_num_workers=1,
+            dataloader_num_workers=0,
             tf32=has_sm80 and not use_cpu,
             bf16=has_sm80 and not use_cpu,
             save_only_model=True,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 0 is a better default than 1. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
