### PR TITLE
Chronos-2: Only pin_memory when device type is cuda

### DIFF
--- a/src/chronos/chronos2/pipeline.py
+++ b/src/chronos/chronos2/pipeline.py
@@ -1126,7 +1126,7 @@ class Chronos2Pipeline(BaseChronosPipeline):
         test_loader = DataLoader(
             test_dataset,
             batch_size=None,
-            num_workers=1,
+            num_workers=0,
             pin_memory=self.model.device.type == "cuda",
             shuffle=False,
             drop_last=False,


### PR DESCRIPTION
*Issue #, if available:* Fixes #430

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
