### PR TITLE
feat(chronos2): add native support for static covariates

### DIFF
--- a/src/chronos/chronos2/config.py
+++ b/src/chronos/chronos2/config.py
@@ -110,6 +110,7 @@ class Chronos2ForecastingConfig:
     use_arcsinh: bool = False
     max_output_patches: int = 1
     time_encoding_scale: int | None = None
+    n_static_covariates: int = 0
 
     @classmethod
     def editable_fields(cls) -> list[str]:


### PR DESCRIPTION
### Feature: Native Support for Static covariates in Chronos-2

**Motivation:**
Currently, incorporating static features (e.g., item metadata, store location) requires repeating them across the temporal dimension to match the context length. This approach is memory-inefficient. This PR introduces a native mechanism to handle static covariates by injecting them as a prefix token in the encoder.

**Technical Implementation:**

1.  **Configuration (`src/chronos/chronos2/config.py`):**
    * Added `n_static_covariates` parameter to `Chronos2ForecastingConfig` to define the number of expected static features.

2.  **Data Loading (`src/chronos/chronos2/dataset.py`):**
    * Updated `Chronos2Dataset` to accept and batch `static_covariates` separately, avoiding temporal duplication.
    * Modified `validate_and_prepare_single_dict_task` to validate and extract static tensors from the input dictionary.

3.  **Model Architecture (`src/chronos/chronos2/model.py`):**
    * Implemented `static_covariates_embedding` (a `ResidualBlock`) in `Chronos2Model` to project static features into the model dimension (`d_model`).
    * Modified `encode()` to inject these embeddings as a prefix to `input_embeds`, allowing the transformer to attend to global context alongside temporal patches.
    * Updated `_validate_input` to ensure static covariates dimensions match the configuration.

**Impact:**
* **Efficiency:** Reduces memory usage for multivariate datasets with rich metadata.
* **Scalability:** Facilitates the training of global models where static attributes are key predictors.