### PR TITLE
Fix XDG_CACHE_HOME typo in boto_utils

### DIFF
--- a/src/chronos/boto_utils.py
+++ b/src/chronos/boto_utils.py
@@ -101,7 +101,7 @@ def cache_model_from_s3(
     boto3_session: boto3.Session | None = None,
 ):
     assert re.match("^s3://([^/]+)/(.*?([^/]+)/?)$", s3_uri) is not None, f"Not a valid S3 URI: {s3_uri}"
-    cache_home = Path(os.environ.get("XGD_CACHE_HOME", os.path.expanduser("~/.cache")))
+    cache_home = Path(os.environ.get("XDG_CACHE_HOME", os.path.expanduser("~/.cache")))
     cache_dir = cache_home / "chronos"
     s3_uri = s3_uri.rstrip("/")
     bucket, prefix = s3_uri.replace("s3://", "").split("/", 1)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix typo `XGD_CACHE_HOME` -> `XDG_CACHE_HOME` in `src/chronos/boto_utils.py` so the documented XDG environment variable is honored when resolving the cache directory.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.