### PR TITLE
Handle missing is_decoder in Transformers 5

### DIFF
--- a/src/chronos/chronos2/model.py
+++ b/src/chronos/chronos2/model.py
@@ -48,7 +48,7 @@ class Chronos2EncoderBlockOutput(ModelOutput):
 class Chronos2EncoderBlock(nn.Module):
     def __init__(self, config: Chronos2CoreConfig):
         super().__init__()
-        assert not config.is_decoder
+        assert not getattr(config, "is_decoder", False)
 
         self.layer = nn.ModuleList()
         self.layer.append(TimeSelfAttention(config))
@@ -99,7 +99,7 @@ class Chronos2EncoderOutput(ModelOutput):
 class Chronos2Encoder(nn.Module):
     def __init__(self, config: Chronos2CoreConfig):
         super().__init__()
-        assert not config.is_decoder
+        assert not getattr(config, "is_decoder", False)
 
         self.block = nn.ModuleList([Chronos2EncoderBlock(config) for i in range(config.num_layers)])
         self.final_layer_norm = Chronos2LayerNorm(config.d_model, eps=config.layer_norm_epsilon)

--- a/test/test_chronos2.py
+++ b/test/test_chronos2.py
@@ -16,6 +16,7 @@ from chronos import BaseChronosPipeline, Chronos2Pipeline
 from chronos.chronos2.config import Chronos2CoreConfig
 from chronos.chronos2.dataset import MAX_REJECTED_SAMPLES, Chronos2Dataset, DatasetMode
 from chronos.chronos2.layers import MHA
+from chronos.chronos2.model import Chronos2Encoder
 from chronos.chronos2.preprocess import from_data_frame
 from chronos.df_utils import make_future_df, normalize_df
 from test.util import create_df, create_future_df, get_forecast_start_times, validate_tensor, timeout_callback
@@ -30,6 +31,17 @@ with open(DUMMY_MODEL_PATH / "config.json") as fp:
 @pytest.fixture
 def pipeline() -> Chronos2Pipeline:
     return BaseChronosPipeline.from_pretrained(DUMMY_MODEL_PATH, device_map="cpu")
+
+
+def test_chronos2_encoder_accepts_config_without_is_decoder():
+    config = Chronos2CoreConfig(d_model=32, d_kv=8, d_ff=32, num_layers=2, num_heads=4)
+
+    if hasattr(config, "is_decoder"):
+        del config.is_decoder
+
+    encoder = Chronos2Encoder(config)
+
+    assert len(encoder.block) == config.num_layers
 
 
 def test_base_chronos2_pipeline_loads_from_s3():


### PR DESCRIPTION
## Summary

- guard the encoder and encoder-block decoder checks when `is_decoder` is absent
- preserve the assertion when a config explicitly sets `is_decoder=True`
- add a regression test that constructs `Chronos2Encoder` without the removed attribute

Fixes #519.

## Root cause

Transformers 5 removed `PretrainedConfig.is_decoder`, while Chronos 2 accessed the attribute directly in both encoder constructors. Since the package supports `transformers<6`, a fresh `Chronos2CoreConfig` on Transformers 5 raised `AttributeError` before the encoder could be constructed.

## Validation

- reproduced with Transformers 5.14.1 and confirmed `Chronos2CoreConfig` has no `is_decoder` attribute
- constructed a two-layer `Chronos2Encoder` successfully after the change
- `python -m compileall -q src/chronos/chronos2/model.py test/test_chronos2.py`
- `git diff --check`
