### PR TITLE
Pass import_allowlist when loading LoRA adapters with peft>=0.20

### DIFF
--- a/src/chronos/chronos2/pipeline.py
+++ b/src/chronos/chronos2/pipeline.py
@@ -1164,6 +1164,14 @@ class Chronos2Pipeline(BaseChronosPipeline):
                 )
             from peft import AutoPeftModel
 
+            # Allow importing the adapter's parent library from our own package.
+            # See https://github.com/huggingface/peft/pull/3090.
+            # The version guard can be dropped once min `peft` is 0.20.
+            from peft import __version__ as peft_version
+
+            if version.parse(peft_version) >= version.parse("0.20.0"):
+                kwargs.setdefault("import_allowlist", ["chronos"])
+
             model = AutoPeftModel.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
             model = model.merge_and_unload()
             return cls(model=model)


### PR DESCRIPTION
## Fix

`peft` 0.20 ([huggingface/peft#3090](https://github.com/huggingface/peft/pull/3090)) enforces an import allowlist when resolving a LoRA adapter's `auto_mapping.parent_library`. For Chronos-2 adapters this is `chronos.chronos2.model`, which is not in the default allowlist, so `Chronos2Pipeline.from_pretrained` on an adapter raises:

```
ValueError: The auto mapping wants to import 'chronos.chronos2.model' which is not in the import allowlist.
```

This broke `test_chronos2_lora_pipeline_loads_from_disk` in CI once `peft` 0.20 was pulled in.

We now pass `import_allowlist=["chronos"]` (peft matches on the module prefix, so this covers any submodule under our own package) when loading an adapter. The call is guarded on `peft>=0.20.0` since the kwarg does not exist in older versions within our supported range (`peft>=0.18.1`); the guard can be dropped once the minimum is 0.20.

## Testing

`test/test_chronos2.py::test_chronos2_lora_pipeline_loads_from_disk` passes with `peft` 0.20.0 installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)