### PR TITLE
Fix embed function

### DIFF
--- a/src/chronos/chronos.py
+++ b/src/chronos/chronos.py
@@ -199,9 +199,9 @@ class MeanScaleUniformBins(ChronosTokenizer):
         self, token_ids: torch.Tensor, attention_mask: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         batch_size = token_ids.shape[0]
-        eos_tokens = torch.full((batch_size, 1), fill_value=self.config.eos_token_id)
+        eos_tokens = torch.full((batch_size, 1), fill_value=self.config.eos_token_id).to(device=token_ids.device)
         token_ids = torch.concat((token_ids, eos_tokens), dim=1)
-        eos_mask = torch.full((batch_size, 1), fill_value=True)
+        eos_mask = torch.full((batch_size, 1), fill_value=True).to(device=attention_mask.device)
         attention_mask = torch.concat((attention_mask, eos_mask), dim=1)
 
         return token_ids, attention_mask
@@ -375,6 +375,8 @@ class ChronosPipeline(BaseChronosPipeline):
     def __init__(self, tokenizer, model):
         super().__init__(inner_model=model.model)
         self.tokenizer = tokenizer
+        if isinstance(tokenizer, MeanScaleUniformBins):
+            tokenizer.boundaries = tokenizer.boundaries.to(device=model.device)
         self.model = model
 
     @property
@@ -424,7 +426,7 @@ class ChronosPipeline(BaseChronosPipeline):
         embeddings = self.model.encode(
             input_ids=token_ids.to(self.model.device),
             attention_mask=attention_mask.to(self.model.device),
-        ).cpu()
+        )
         return embeddings, tokenizer_state
 
     def predict(

--- a/src/chronos/chronos2/pipeline.py
+++ b/src/chronos/chronos2/pipeline.py
@@ -625,7 +625,7 @@ class Chronos2Pipeline(BaseChronosPipeline):
             mode=DatasetMode.TEST,
         )
         test_loader = DataLoader(
-            test_dataset, batch_size=None, pin_memory=self.model.device.type == "cuda", shuffle=False, drop_last=False
+            test_dataset, batch_size=None, pin_memory=self.model.device.type == "cpu", shuffle=False, drop_last=False
         )
 
         all_predictions: list[torch.Tensor] = []
@@ -1131,11 +1131,11 @@ class Chronos2Pipeline(BaseChronosPipeline):
                 context=batch_context.to(device=self.model.device, dtype=torch.float32),
                 group_ids=batch_group_ids.to(self.model.device),
             )
-            batch_embeds = [encoder_outputs[0][start:end].cpu() for (start, end) in batch_target_idx_ranges]
+            batch_embeds = [encoder_outputs[0][start:end] for (start, end) in batch_target_idx_ranges]
             batch_loc_scales = list(
                 zip(
-                    [locs[start:end].cpu() for (start, end) in batch_target_idx_ranges],
-                    [scales[start:end].cpu() for (start, end) in batch_target_idx_ranges],
+                    [locs[start:end] for (start, end) in batch_target_idx_ranges],
+                    [scales[start:end] for (start, end) in batch_target_idx_ranges],
                 )
             )
             all_embeds.extend(batch_embeds)


### PR DESCRIPTION
*Issue #, if available:*
#522 
*Description of changes:*
- Fixed Chronos2 Pipeline to accept and return cuda tensors if required:
-- Removed cpu() mapping functions.
-- Fixed pin_memory in test_loader: It doesn't make sense to set pin_memory to True when model is in CUDA.
- Fixed Chronos Pipeline to accept and return cuda tensors if required:
-- Set the device for eos_token and eos_mask to match the ones in token_ids and attention_mask, respectively.
-- If the tokenizer is MeanScaleUniformBins, then its boundaries's device must match model's device.
-- Removed cpu() mapping function inside embed().

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
