### PR TITLE
fix: preserve timezone-aware timestamps during dataframe normalization

### DIFF
--- a/src/chronos/df_utils.py
+++ b/src/chronos/df_utils.py
@@ -124,9 +124,9 @@ def normalize_df(
             missing = pd.unique(df[id_column][codes < 0])
             raise ValueError(f"future_df has ids not present in df: {list(missing)[:5]}")
 
-    # View as int64 (datetime64 is int64-backed) so np.diff yields integers; comparing
-    # the timedelta64 from np.diff against 0 raises UFuncTypeError on numpy<2.0.
-    ts = df[timestamp_column].to_numpy().view("int64")
+    # Use integer timestamps so np.diff works on numpy<2.0 and timezone-aware
+    # values are ordered by absolute time without converting to an object array.
+    ts = pd.DatetimeIndex(df[timestamp_column]).asi8
     code_diff = np.diff(codes)
     grouped = bool(np.all(code_diff >= 0))
     sorted_within = grouped and bool(np.all((np.diff(ts) >= 0) | (code_diff > 0)))

--- a/test/test_chronos2.py
+++ b/test/test_chronos2.py
@@ -615,6 +615,22 @@ def test_predict_df_with_future_df_with_different_lengths_raises_error(pipeline)
         pipeline.predict_df(df, future_df=future_df, prediction_length=3)
 
 
+@pytest.mark.parametrize("with_future_covariates", [False, True])
+def test_predict_df_preserves_timezone_across_dst(pipeline, with_future_covariates):
+    timestamps = pd.date_range("2025-11-01 22:00", periods=8, freq="h", tz="America/New_York")
+    df = pd.DataFrame(
+        {"item_id": "A", "timestamp": timestamps[:4], "target": np.arange(4, dtype=float), "cov": 1.0}
+    )
+    future_df = None
+    if with_future_covariates:
+        future_df = pd.DataFrame({"item_id": "A", "timestamp": timestamps[4:], "cov": 1.0}).iloc[::-1]
+
+    result = pipeline.predict_df(df.iloc[::-1], future_df=future_df, prediction_length=4)
+
+    pd.testing.assert_index_equal(pd.DatetimeIndex(result["timestamp"]), timestamps[4:].rename("timestamp"))
+    assert np.isfinite(result["predictions"]).all()
+
+
 def test_predict_df_matches_manual_preprocess_path(pipeline):
     """predict_df must produce the same output as manually preprocessing the df with
     from_data_frame + make_future_df and assembling the result (multi-target, numeric +

--- a/test/test_df_utils.py
+++ b/test/test_df_utils.py
@@ -128,6 +128,30 @@ def test_normalize_df_coerces_string_timestamps_to_datetime():
     assert pd.api.types.is_datetime64_any_dtype(out["timestamp"])
 
 
+@pytest.mark.parametrize("tz", ["UTC", "Asia/Shanghai", "America/New_York"])
+@pytest.mark.parametrize("already_sorted", [False, True])
+def test_normalize_df_preserves_timezone_and_sorts_by_absolute_time(tz, already_sorted):
+    timestamps = pd.date_range("2025-11-02", periods=4, freq="h", tz=tz)
+    df = pd.DataFrame(
+        {
+            "item_id": ["B", "A", "B", "A"],
+            "timestamp": timestamps[[2, 1, 0, 3]],
+            "target": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+    expected = df.iloc[[2, 0, 1, 3]].reset_index(drop=True)
+    if already_sorted:
+        df = expected.copy()
+    original = df.copy()
+
+    out = normalize_df(df)
+
+    pd.testing.assert_frame_equal(out, expected)
+    pd.testing.assert_frame_equal(df, original)
+    if already_sorted:
+        assert out is df
+
+
 def test_normalize_df_respects_explicit_order():
     df = pd.DataFrame(
         {


### PR DESCRIPTION
*Issue #, if available:*

No existing issue found for this timezone failure. The affected normalization helper is from #507; this is separate from the string-ID ordering fix in #470.

*Description of changes:*

`predict_df` currently raises `TypeError: Cannot change data-type for array of references` when the timestamp column is timezone-aware. `Series.to_numpy()` produces an object array for these timestamps, which cannot be viewed as `int64`.

Read the ordering keys from `DatetimeIndex.asi8` instead. The returned DataFrame keeps its original timezone, while sorting uses absolute time, including repeated local hours during a daylight-saving transition. This also retains integer comparisons for NumPy 1.x.

The regression tests cover UTC, Asia/Shanghai and America/New_York; sorted and unsorted input; caller immutability; and actual CPU `predict_df` calls across the New York DST fold, with and without future covariates.

Validation on the same upstream base (`4dbf163c2734c089cdf7da2b86fde48862ff9c6f`):

- `python -m pytest test/test_df_utils.py test/test_chronos2.py -k preserves_timezone -q`: **8 failures before, 8 passes after**, using identical test files.
- `OMP_NUM_THREADS=1 python -m pytest -q`: **564 passed, 20 xfailed**, with no deselected tests, including public model and dataset downloads.
- NumPy 1.26.4 / pandas 2.3.3 compatibility: **553 passed, 20 xfailed**; the 11 external-download cases were excluded in this second environment.
- `python -m mypy src test` and `uv build`: passed.

Environment: macOS arm64, Python 3.11.15, PyTorch 2.14.0, Transformers 5.17.0; primary suite used NumPy 2.4.6 and pandas 3.0.5. The suite emits its existing long-horizon warnings and a CloudFront deprecation warning. An additional Ruff 0.16.7 check reports the same 130 diagnostics on the unmodified base and patch, with no new diagnostics; no unrelated lint cleanup is included.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
